### PR TITLE
Change README example code from "YammerPHP($config);" to "YammerPHP\YammerPHP($config);"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $config['consumer_key'] = '1ABCdefhiJKLmnop';
 $config['consumer_secret'] = 'ABCdefhi_JKLmnop';
 $config['callbackUrl'] = 'http://' . $_SERVER['SERVER_NAME'] . '/yammer/callback/';
 
-$yammer = new YammerPHP($config);
+$yammer = new YammerPHP\YammerPHP($config);
 ```
 
 Starting the callback process:


### PR DESCRIPTION
Fixes "PHP Fatal error:  Class 'YammerPHP' not found..."
Found fix by looking at https://github.com/stephenyeargin/yammer-oauth2-php/blob/master/tests/YammerPHP/YammerPHP_Test.php

There may be a reason you didn't include this but if not, here's a PR to add it. 

Thanks!
- Elijah
