### PR TITLE
Update example in readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ if (!$yammer->testAuth()) {
 
 // Retrieve feed for authenticated user
 try {
-    $feed = $yammer->request('messages/my_feed.json');
+    $feed = $yammer->get('messages/my_feed.json');
     print_r($feed);
 } catch (YammerPHPException $e) {
     print 'Error: ';


### PR DESCRIPTION
The **request** method is a private function so this example will fail. I believe the **get** method would be the correct one to use in this example.